### PR TITLE
Sprint7

### DIFF
--- a/FieldParam.java
+++ b/FieldParam.java
@@ -1,0 +1,9 @@
+package mg.itu.prom16.annotation;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface FieldParam {
+    String name();
+}

--- a/RequestObject.java
+++ b/RequestObject.java
@@ -1,0 +1,8 @@
+package mg.itu.prom16.annotation;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RequestObject {
+}


### PR DESCRIPTION
Objectif:
Permettre de mettre en paramètre d'une fonction de mapping un objet et de setup ses attributs.

Etape 1: Créer une annotation pour l'objet en paramètre
Etape 2: Créer un process qui va s'effectuer automatiquement lors que le programme détecte l'annotation créée plus tôt
-> Ce process va bouclé tous les attributs de l'objet pour obtenir leurs valeurs attribuées dans request.getParameter
-> Créer une nouvelle annotation de type ElementType.FIELD pour donner le choix aux utilisateurs du framework le choix entre 
utilisé le même nom dans sa classe et son formulaire ou annoté l'attribut avec le nom présent dans son formulaire sans devoir à utilisé le même nom
on peut utiliser -parameters lors de la compilation